### PR TITLE
DOC: Adding alt-text to images in the documentation.

### DIFF
--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -264,6 +264,7 @@ consider carefully if any surprising behavior results.
    Type casting hierarchy.
 
    .. image:: _static/nep0013_image1.png
+       :alt: <Alternative text here>
 
    The ``__array_ufunc__`` of type A can handle ndarrays returning C,
    B can handle ndarray and D returning B, and C can handle A and B returning C,
@@ -280,6 +281,7 @@ consider carefully if any surprising behavior results.
    One-cycle in the ``__array_ufunc__`` graph.
 
    .. image:: _static/nep0013_image2.png
+       :alt: <Alternative text here>
 
    In this case, the ``__array_ufunc__`` relations have a cycle of length 1,
    and a type casting hierarchy does not exist. Binary operations are not
@@ -290,6 +292,7 @@ consider carefully if any surprising behavior results.
    Longer cycle in the ``__array_ufunc__`` graph.
 
    .. image:: _static/nep0013_image3.png
+       :alt: <Alternative text here>
 
    In this case, the ``__array_ufunc__`` relations have a longer cycle, and a
    type casting hierarchy does not exist. Binary operations are still

--- a/doc/neps/nep-0041-improved-dtype-support.rst
+++ b/doc/neps/nep-0041-improved-dtype-support.rst
@@ -468,7 +468,7 @@ however, it highlights that the DType datatype class is the central, necessary
 concept:
 
 .. image:: _static/nep-0041-mindmap.svg
-
+  :alt: <Alternative text here>
 
 First steps directly related to this NEP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -636,6 +636,7 @@ These two options are presented in the following figure and compared to
 similar Python implementation patterns:
 
 .. image:: _static/nep-0041-type-sketch-no-fonts.svg
+  :alt: <Alternative text here>
 
 The difference is in how parameters, such as string length or the datetime
 units (``ms``, ``ns``, ...), and storage options, such as byte-order, are handled.

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -418,6 +418,7 @@ Click on the 'Admin' button, and add anyone else to the repo as a
 collaborator:
 
    .. image:: pull_button.png
+     :alt: <Alternative text here>
 
 Now all those people can do::
 

--- a/doc/source/dev/gitwash/development_setup.rst
+++ b/doc/source/dev/gitwash/development_setup.rst
@@ -52,15 +52,17 @@ Create the fork repo
 #. At the upper right of the page, click ``Fork``:
 
    .. image:: forking_button.png
+     :alt: <Alternative text here>
 
    You'll see
 
    .. image:: forking_message.png
+     :alt: <Alternative text here>
 
    and then you'll be taken to the home page of your forked copy:
 
    .. image:: forked_page.png
-
+     :alt: <Alternative text here>
 
 .. _set-up-fork:
 

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -206,6 +206,7 @@ to, you can also specify the type of data in your list.
 You can visualize your array this way:
 
 .. image:: images/np_array.png
+  :alt: <Alternative text here>
 
 *Be aware that these visualizations are meant to simplify ideas and give you a basic understanding of NumPy concepts and mechanics. Arrays and array operations are much more complicated than are captured here!*
 
@@ -504,7 +505,7 @@ lists. ::
 You can visualize it this way:
 
 .. image:: images/np_indexing.png
-
+  :alt: <Alternative text here>
 
 You may want to take a section of your array or specific array elements to use
 in further analysis or additional operations. To do that, you'll need to subset,
@@ -728,6 +729,7 @@ for example, that you've created two arrays, one called "data" and one called
 "ones"
 
 .. image:: images/np_array_dataones.png
+  :alt: <Alternative text here>
 
 You can add the arrays together with the plus sign.
 
@@ -739,6 +741,7 @@ You can add the arrays together with the plus sign.
   array([2, 3])
 
 .. image:: images/np_data_plus_ones.png
+  :alt: <Alternative text here>
 
 You can, of course, do more than just addition!
 
@@ -752,6 +755,7 @@ You can, of course, do more than just addition!
   array([1., 1.])
 
 .. image:: images/np_sub_mult_divide.png
+  :alt: <Alternative text here>
 
 Basic operations are simple with NumPy. If you want to find the sum of the
 elements in an array, you'd use ``sum()``. This works for 1D arrays, 2D arrays,
@@ -795,6 +799,7 @@ convert the information to kilometers. You can perform this operation with::
   array([1.6, 3.2])
 
 .. image:: images/np_multiply_broadcasting.png
+  :alt: <Alternative text here>
 
 NumPy understands that the multiplication should happen with each cell. That
 concept is called **broadcasting**. Broadcasting is a mechanism that allows
@@ -826,6 +831,7 @@ deviation, and more. ::
   3.0
 
 .. image:: images/np_aggregation.png
+  :alt: <Alternative text here>
 
 Let's start with this array, called "a" ::
 
@@ -871,6 +877,7 @@ represent them in NumPy. ::
          [5, 6]])
 
 .. image:: images/np_create_matrix.png
+  :alt: <Alternative text here>
 
 Indexing and slicing operations are useful when you're manipulating matrices::
 
@@ -883,6 +890,7 @@ Indexing and slicing operations are useful when you're manipulating matrices::
   array([1, 3])
 
 .. image:: images/np_matrix_indexing.png
+  :alt: <Alternative text here>
 
 You can aggregate matrices the same way you aggregated vectors::
 
@@ -894,6 +902,7 @@ You can aggregate matrices the same way you aggregated vectors::
   21
 
 .. image:: images/np_matrix_aggregation.png
+  :alt: <Alternative text here>
 
 You can aggregate all the values in a matrix and you can aggregate them across
 columns or rows using the ``axis`` parameter::
@@ -904,6 +913,7 @@ columns or rows using the ``axis`` parameter::
   array([2, 4, 6])
 
 .. image:: images/np_matrix_aggregation_row.png
+  :alt: <Alternative text here>
 
 Once you've created your matrices, you can add and multiply them using
 arithmetic operators if you have two matrices that are the same size. ::
@@ -915,6 +925,7 @@ arithmetic operators if you have two matrices that are the same size. ::
          [4, 5]])
 
 .. image:: images/np_matrix_arithmetic.png
+  :alt: <Alternative text here>
 
 You can do these arithmetic operations on matrices of different sizes, but only
 if one matrix has only one column or one row. In this case, NumPy will use its
@@ -928,6 +939,7 @@ broadcast rules for the operation. ::
          [6, 7]])
 
 .. image:: images/np_matrix_broadcasting.png
+  :alt: <Alternative text here>
 
 Be aware that when NumPy prints N-dimensional arrays, the last axis is looped
 over the fastest while the first axis is the slowest. For instance::
@@ -964,6 +976,7 @@ All you need to do is pass in the number of elements you want it to generate::
   array([0.63696169, 0.26978671, 0.04097352])
 
 .. image:: images/np_ones_zeros_random.png
+  :alt: <Alternative text here>
 
 You can also use ``ones()``, ``zeros()``, and ``random()`` to create
 a 2D array if you give them a tuple describing the dimensions of the matrix::
@@ -982,6 +995,7 @@ a 2D array if you give them a tuple describing the dimensions of the matrix::
          [0.72949656, 0.54362499]])  # may vary
 
 .. image:: images/np_ones_zeros_matrix.png
+  :alt: <Alternative text here>
 
 Read more about creating arrays, filled with ``0``'s, ``1``'s, other values or
 uninitialized, at :ref:`array creation routines <routines.array-creation>`.
@@ -1093,6 +1107,7 @@ It's common to need to transpose your matrices. NumPy arrays have the property
 ``T`` that allows you to transpose a matrix.
 
 .. image:: images/np_transposing_reshaping.png
+  :alt: <Alternative text here>
 
 You may also need to switch the dimensions of a matrix. This can happen when,
 for example, you have a model that expects a certain input shape that is
@@ -1108,6 +1123,7 @@ You simply need to pass in the new dimensions that you want for the matrix. ::
          [5, 6]])
 
 .. image:: images/np_reshape.png
+  :alt: <Alternative text here>
 
 You can also use ``.transpose()`` to reverse or change the axes of an array
 according to the values you specify.
@@ -1434,10 +1450,12 @@ For example, this is the mean square error formula (a central formula used in
 supervised machine learning models that deal with regression):
 
 .. image:: images/np_MSE_formula.png
+  :alt: <Alternative text here>
 
 Implementing this formula is simple and straightforward in NumPy:
 
 .. image:: images/np_MSE_implementation.png
+  :alt: <Alternative text here>
 
 What makes this work so well is that ``predictions`` and ``labels`` can contain
 one or a thousand values. They only need to be the same size.
@@ -1445,6 +1463,7 @@ one or a thousand values. They only need to be the same size.
 You can visualize it this way:
 
 .. image:: images/np_mse_viz1.png
+  :alt: <Alternative text here>
 
 In this example, both the predictions and labels vectors contain three values,
 meaning ``n`` has a value of three. After we carry out subtractions the values
@@ -1452,9 +1471,10 @@ in the vector are squared. Then NumPy sums the values, and your result is the
 error value for that prediction and a score for the quality of the model.
 
 .. image:: images/np_mse_viz2.png
+  :alt: <Alternative text here>
 
 .. image:: images/np_MSE_explanation2.png
-
+  :alt: <Alternative text here>
 
 How to save and load NumPy objects
 ----------------------------------
@@ -1566,6 +1586,7 @@ easiest way to do this is to use
    ['SIA' 74000000]]
 
 .. image:: images/np_pandas.png
+  :alt: <Alternative text here>
 
 It's simple to use Pandas in order to export your array as well. If you are new
 to NumPy, you may want to  create a Pandas dataframe from the values in your
@@ -1601,6 +1622,7 @@ And read your CSV with::
   >>> data = pd.read_csv('pd.csv')
 
 .. image:: images/np_readcsv.png
+  :alt: <Alternative text here>
 
 You can also save your array with the NumPy ``savetxt`` method. ::
 
@@ -1653,6 +1675,7 @@ All you need to do to plot your values is run::
 .. plot:: user/plots/matplotlib1.py
    :align: center
    :include-source: 0
+   :alt: <Alternative text here>
 
 For example, you can plot a 1D array like this::
 
@@ -1664,6 +1687,7 @@ For example, you can plot a 1D array like this::
 .. plot:: user/plots/matplotlib2.py
    :align: center
    :include-source: 0
+   :alt: <Alternative text here>
 
 With Matplotlib, you have access to an enormous number of visualization options. ::
 
@@ -1680,6 +1704,7 @@ With Matplotlib, you have access to an enormous number of visualization options.
 .. plot:: user/plots/matplotlib3.py
    :align: center
    :include-source: 0
+   :alt: <Alternative text here>
 
 
 To read more about Matplotlib and what it can do, take a look at

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1251,6 +1251,7 @@ how to use boolean indexing to generate an image of the `Mandelbrot
 set <https://en.wikipedia.org/wiki/Mandelbrot_set>`__:
 
 .. plot::
+  :alt: <Alternative text here>
 
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
@@ -1458,6 +1459,7 @@ that ``pylab.hist`` plots the histogram automatically, while
 ``numpy.histogram`` only generates the data.
 
 .. plot::
+  :alt: <Alternative text here>
 
     >>> import numpy as np
     >>> rg = np.random.default_rng(1)


### PR DESCRIPTION
This PR is part of the [Accessibility Mini-Sprint](https://mail.python.org/pipermail/numpy-discussion/2021-July/081984.html) happening on July 29 at 8PM UTC. 

UPDATE: Continuing the sprint, this is also to be used on August 12 at 4PM UTC.

### Instructions:

- Add each alternative text for the images as suggestions on this PR.
- To open the images, check the [documentation built from these sources here](https://numpy.org/devdocs), [using Gitpod](https://numpy.org/devdocs/dev/development_gitpod.html), or [building locally](https://numpy.org/devdocs/docs/howto_build_docs.html).
   - Rendered page for `doc/source/dev/development_workflow.rst`: [Development workflow](https://numpy.org/devdocs/dev/development_workflow.html)
   - Rendered page for `doc/source/dev/gitwash/development_setup.rst`: [Setting up git for NumPy development](https://numpy.org/devdocs/dev/gitwash/development_setup.html)
   - Rendered page for `doc/source/user/absolute_beginners.rst`: [NumPy: the absolute basics for beginners](https://numpy.org/devdocs/user/absolute_beginners.html)
   - Rendered page for `doc/source/user/quickstart.rst`: [NumPy Quickstart](https://numpy.org/devdocs/user/quickstart.html)
   - Rendered page for `doc/neps/nep-0013-ufunc-overrides.rst`: [NEP 13](https://numpy.org/neps/nep-0013-ufunc-overrides.html)
   - Rendered page for `doc/neps/nep-0041-improved-dtype-support.rst`: [NEP 41](https://numpy.org/neps/nep-0041-improved-dtype-support.html)

These images are grouped into three types:
- Screenshots: `doc/source/dev/development_workflow.rst`, `doc/source/dev/gitwash/development_setup.rst`
- Diagrams: `doc/source/user/absolute_beginners.rst`, `doc/neps/nep-0013-ufunc-overrides.rst`, `doc/neps/nep-0041-improved-dtype-support.rst`
- Plots: `doc/source/user/absolute_beginners.rst`, `doc/source/user/quickstart.rst`

### Details

> Alternative text serves several functions:
>
>   - It is read by screen readers in place of images allowing the content and function of the image to be accessible to those with visual or certain cognitive disabilities.
>   - It is displayed in place of the image in browsers if the image file is not loaded or when the user has chosen not to view images.
>   - It provides a semantic meaning and description to images which can be read by search engines or be used to later determine the content of the image from page context alone.

Source: [WebAIM: Alternative Text](https://webaim.org/techniques/alttext/)

You can find some more information on how to add alt-text in [this Web Accessibility Tutorial](https://www.w3.org/WAI/tutorials/images/decision-tree/).